### PR TITLE
Fix path detection bug in bin/install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,14 +8,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   export AWS_ACCESS_KEY=$(cat infra/variables.tfvars.local | grep -m 1 aws_access_key | awk '{ v=$3; gsub(/"/, "", v); print v }')
   export AWS_SECRET_KEY=$(cat infra/variables.tfvars.local | grep -m 1 aws_secret_key | awk '{ v=$3; gsub(/"/, "", v); print v }')
 else
-  PYTHON_BASE=$(pip show s3cmd | awk '/^Location/ {split($2, a, "/lib"); print a[1]}')
-  export PATH="$PATH:$PYTHON_BASE/bin"
-  echo $PATH
   pip install --upgrade pip
   pip install s3cmd
 
   sleep 5
 
+  PYTHON_BASE=$(pip show s3cmd | awk '/^Location/ {split($2, a, "/lib"); print a[1]}')
+  export PATH="$PATH:$PYTHON_BASE/bin"
   ls "$PYTHON_BASE/bin"
 fi
 


### PR DESCRIPTION
## Summary
- fix detection of Python bin path in `bin/install`
- restore the sleep delay before locating the s3cmd path

## Testing
- `bash -n bin/install`


------
https://chatgpt.com/codex/tasks/task_e_6841f33382888329bf85df40531055f8