### PR TITLE
Fix typo in font bucket comment

### DIFF
--- a/infra/font-bucket.tf
+++ b/infra/font-bucket.tf
@@ -1,4 +1,4 @@
-# created this user in the UI with programatic access and zero permissions
+# created this user in the UI with programmatic access and zero permissions
 # and then ran $ ./import aws_iam_user.font_bucketeer font_bucketeer
 resource "aws_iam_user" "font_bucketeer" {
   name = "font_bucketeer"


### PR DESCRIPTION
## Summary
- update typo in `infra/font-bucket.tf`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f4b70380832998e2978458f7d6cc